### PR TITLE
Support for readline (command history in repl)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 add_executable(eople ${eople_SOURCES})
+target_link_libraries(eople -lreadline)
 
 install(TARGETS eople DESTINATION /usr/local/bin)
 # install(FILES ../icon/eople.png DESTINATION /usr/share/icons)


### PR DESCRIPTION
Added bash-like history (saved across sessions) + reverse search.
Fixed funky line endings in eople_eve.cpp